### PR TITLE
Zend\Authentication\Validator\Authentication messages translation

### DIFF
--- a/languages/en/Zend_Validate.php
+++ b/languages/en/Zend_Validate.php
@@ -8,9 +8,15 @@
  */
 
 /**
- * EN-Revision: 08.Apr.2015
+ * EN-Revision: 16.Jun.2015
  */
 return array(
+    // Zend\Authentication\Validator\Authentication
+    "Invalid identity" => "Invalid identity",
+    "Identity is ambiguous" => "Identity is ambiguous",
+    "Invalid password" => "Invalid password",
+    "Authentication failed" => "Authentication failed",
+
     // Zend\I18n\Validator\Alnum
     "Invalid type given. String, integer or float expected" => "Invalid type given. String, integer or float expected",
     "The input contains characters which are non alphabetic and no digits" => "The input contains characters which are non alphabetic and no digits",

--- a/languages/pt_BR/Zend_Validate.php
+++ b/languages/pt_BR/Zend_Validate.php
@@ -11,6 +11,12 @@
  * EN-Revision: 06.Feb.2013
  */
 return array(
+    // Zend\Authentication\Validator\Authentication
+    "Invalid identity" => "Identidade inválida",
+    "Identity is ambiguous" => "Mais de uma identidade encontrada",
+    "Invalid password" => "Senha incorreta",
+    "Authentication failed" => "Autenticação falhou",
+
     // Zend_I18n_Validator_Alnum
     "Invalid type given. String, integer or float expected" => "O tipo especificado é inválido, o valor deve ser float, string, ou inteiro",
     "The input contains characters which are non alphabetic and no digits" => "O valor de entrada contém caracteres que não são alfabéticos e nem dígitos",


### PR DESCRIPTION
It seems the authentication validator messages are not being translated anywhere. This PR adds these messages to the _en_ translation and also the _pt_BR_ translation.
