### PR TITLE
fix: translate base Zend\Validator\GreaterThan

### DIFF
--- a/languages/bg/Zend_Validate.php
+++ b/languages/bg/Zend_Validate.php
@@ -202,7 +202,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "Въведената стойност не е по-голяма от '%min%'",
-    "The input is not greater or equal than '%min%'" => "Въведената стойност не е по-голяма или равна на '%min%'",
+    "The input is not greater than or equal to '%min%'" => "Въведената стойност не е по-голяма или равна на '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Зададен е невалиден тип данни. Очаква се стринг",

--- a/languages/ca/Zend_Validate.php
+++ b/languages/ca/Zend_Validate.php
@@ -210,7 +210,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "L'entrada no és més gran que '%min%'",
-    "The input is not greater or equal than '%min%'" => "L'entrada no és més gran o igual que '%min%'",
+    "The input is not greater than or equal to '%min%'" => "L'entrada no és més gran o igual que '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Tipus no vàlid donat. S'espera una cadena de text",

--- a/languages/cs/Zend_Validate.php
+++ b/languages/cs/Zend_Validate.php
@@ -202,7 +202,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "Hodnota není větší než '%min%'",
-    "The input is not greater or equal than '%min%'" => "Hodnota není větší nebo rovna '%min%'",
+    "The input is not greater than or equal to '%min%'" => "Hodnota není větší nebo rovna '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Chybný typ. Byl očekáván řetězec",

--- a/languages/da/Zend_Validate.php
+++ b/languages/da/Zend_Validate.php
@@ -217,7 +217,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "Indtastningen er ikke større end '%min%'",
-    "The input is not greater or equal than '%min%'" => "Indtastningen indeholder ikke mere end, eller er præcis, '%min%'",
+    "The input is not greater than or equal to '%min%'" => "Indtastningen indeholder ikke mere end, eller er præcis, '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Ugyldig indtastning. Indtast streng",

--- a/languages/de/Zend_Validate.php
+++ b/languages/de/Zend_Validate.php
@@ -205,7 +205,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "Die Eingabe ist nicht größer als '%min%'",
-    "The input is not greater or equal than '%min%'" => "Die Eingabe ist nicht größer oder gleich '%min%'",
+    "The input is not greater than or equal to '%min%'" => "Die Eingabe ist nicht größer oder gleich '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Ungültige Eingabe. Zeichenkette erwartet",

--- a/languages/en/Zend_Validate.php
+++ b/languages/en/Zend_Validate.php
@@ -216,7 +216,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "The input is not greater than '%min%'",
-    "The input is not greater or equal than '%min%'" => "The input is not greater or equal than '%min%'",
+    "The input is not greater than or equal to '%min%'" => "The input is not greater than or equal to '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Invalid type given. String expected",

--- a/languages/es/Zend_Validate.php
+++ b/languages/es/Zend_Validate.php
@@ -202,7 +202,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "El valor especificado no es más grande que '%min%'",
-    "The input is not greater or equal than '%min%'" => "El valor especificado no es más grande o igual que '%min%'",
+    "The input is not greater than or equal to '%min%'" => "El valor especificado no es más grande o igual que '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "El tipo especificado es incorrecto, el valor debería ser una cadena de texto",

--- a/languages/fr/Zend_Validate.php
+++ b/languages/fr/Zend_Validate.php
@@ -200,7 +200,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "L'entrée n'est pas supérieure à '%min%'",
-    "The input is not greater or equal than '%min%'" => "L'entrée n'est pas supérieure ou égale à '%min%'",
+    "The input is not greater than or equal to '%min%'" => "L'entrée n'est pas supérieure ou égale à '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Type invalide. Chaîne attendue",

--- a/languages/hu/Zend_Validate.php
+++ b/languages/hu/Zend_Validate.php
@@ -202,7 +202,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "A megadott érték nem nagyobb, mint '%min%'",
-    "The input is not greater or equal than '%min%'" => "A megadott érték nem nagyobb vagy egyenlő, mint '%min%'",
+    "The input is not greater than or equal to '%min%'" => "A megadott érték nem nagyobb vagy egyenlő, mint '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Érvénytelen típus. Érvényes típusok: karakterláncok",

--- a/languages/id/Zend_Validate.php
+++ b/languages/id/Zend_Validate.php
@@ -175,7 +175,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "Isian tidak lebih besar dari '%min%'",
-    "The input is not greater or equal than '%min%'" => "Isian tidak lebih besar atau sama dengan '%min%'",
+    "The input is not greater than or equal to '%min%'" => "Isian tidak lebih besar atau sama dengan '%min%'",
 
     // Zend\Validator\Hex
     "The input contains non-hexadecimal characters" => "Isian berisi karakter non-heksadesimal",

--- a/languages/it/Zend_Validate.php
+++ b/languages/it/Zend_Validate.php
@@ -202,7 +202,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "L'input non è maggiore di '%min%'",
-    "The input is not greater or equal than '%min%'" => "L'input non è maggiore o uguale a '%min%'",
+    "The input is not greater than or equal to '%min%'" => "L'input non è maggiore o uguale a '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Tipo di dato non valido. Era attesto un dato di tipo string",

--- a/languages/ja/Zend_Validate.php
+++ b/languages/ja/Zend_Validate.php
@@ -202,7 +202,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => " 入力値は '%min%' より大きくありません",
-    "The input is not greater or equal than '%min%'" => "入力値は '%min%' 以上ではありません",
+    "The input is not greater than or equal to '%min%'" => "入力値は '%min%' 以上ではありません",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "不正な形式です。文字列が期待されています",

--- a/languages/nl/Zend_Validate.php
+++ b/languages/nl/Zend_Validate.php
@@ -202,7 +202,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "De input is niet groter dan '%min%'",
-    "The input is not greater or equal than '%min%'" => "De input is niet groter dan of gelijk aan '%min%'",
+    "The input is not greater than or equal to '%min%'" => "De input is niet groter dan of gelijk aan '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Ongeldig type gegeven, waarde moet een string zijn",

--- a/languages/pl/Zend_Validate.php
+++ b/languages/pl/Zend_Validate.php
@@ -186,7 +186,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "Podana wartość nie jest większa niż '%min%'",
-    "The input is not greater or equal than '%min%'" => "Podana wartość nie jest większa lub równa od '%min%'",
+    "The input is not greater than or equal to '%min%'" => "Podana wartość nie jest większa lub równa od '%min%'",
 
     // Zend\Validator\Hex
     "The input contains non-hexadecimal characters" => "Wartość nie jest wartością heksadecymalną",

--- a/languages/pt_BR/Zend_Validate.php
+++ b/languages/pt_BR/Zend_Validate.php
@@ -215,7 +215,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "O valor de entrada não é maior do que '%min%'",
-    "The input is not greater or equal than '%min%'" => "O valor de entrada não é maior ou igual a '%min%'",
+    "The input is not greater than or equal to '%min%'" => "O valor de entrada não é maior ou igual a '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "O tipo especificado é inválido, o valor deve ser to tipo string",

--- a/languages/ru/Zend_Validate.php
+++ b/languages/ru/Zend_Validate.php
@@ -210,7 +210,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "Значение не превышает '%min%'",
-    "The input is not greater or equal than '%min%'" => "Значение не превышает или не равно '%min%'",
+    "The input is not greater than or equal to '%min%'" => "Значение не превышает или не равно '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Недопустимый тип данных. Значение должно быть строкой",

--- a/languages/se/Zend_Validate.php
+++ b/languages/se/Zend_Validate.php
@@ -195,7 +195,7 @@ return [
 
     // Zend_Validator_GreaterThan
     "The input is not greater than '%min%'" => "Indatan är inte större än '%min%'",
-    "The input is not greater or equal than '%min%'" => "Indatan är inte större eller lika med '%min%'",
+    "The input is not greater than or equal to '%min%'" => "Indatan är inte större eller lika med '%min%'",
 
     // Zend_Validator_Hex
     "Invalid type given. String expected" => "Ogiltig typ given. Sträng förväntad",

--- a/languages/sk/Zend_Validate.php
+++ b/languages/sk/Zend_Validate.php
@@ -202,7 +202,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "Hodnota nie je väčšia ako '%min%'",
-    "The input is not greater or equal than '%min%'" => "Hodnota nie je väčšia alebo rovná '%min%'",
+    "The input is not greater than or equal to '%min%'" => "Hodnota nie je väčšia alebo rovná '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Chybný typ. Bol očakávaný reťazec",

--- a/languages/sl/Zend_Validate.php
+++ b/languages/sl/Zend_Validate.php
@@ -216,7 +216,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "Vnos ni večji od '%min%'",
-    "The input is not greater or equal than '%min%'" => "Vnos ni večji ali enak '%min%'",
+    "The input is not greater than or equal to '%min%'" => "Vnos ni večji ali enak '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Podan je neveljaven tip. Pričakuje se niz",

--- a/languages/tr/Zend_Validate.php
+++ b/languages/tr/Zend_Validate.php
@@ -183,7 +183,7 @@ return [
 
     // Zend_Validator_GreaterThan
     "The input is not greater than '%min%'" => "Girdi '%min%' değerinden büyük değil",
-    "The input is not greater or equal than '%min%'" => "Girdi '%min%' değerinden büyük ya da eşit değil",
+    "The input is not greater than or equal to '%min%'" => "Girdi '%min%' değerinden büyük ya da eşit değil",
 
     // Zend_Validator_Hex
     "Invalid type given. String expected" => "Yanlış tür verildi. Dizge bekleniyor",

--- a/languages/uk/Zend_Validate.php
+++ b/languages/uk/Zend_Validate.php
@@ -203,7 +203,7 @@ return [
 
     // Zend\Validator\GreaterThan
     "The input is not greater than '%min%'" => "Значення не є більшим за '%min%'",
-    "The input is not greater or equal than '%min%'" => "Значення не дорівнює і не є більшим за '%min%'",
+    "The input is not greater than or equal to '%min%'" => "Значення не дорівнює і не є більшим за '%min%'",
 
     // Zend\Validator\Hex
     "Invalid type given. String expected" => "Неправильний тип даних. Значення має бути рядком",

--- a/languages/zh/Zend_Validate.php
+++ b/languages/zh/Zend_Validate.php
@@ -183,7 +183,7 @@ return [
 
     // Zend_Validator_GreaterThan
     "The input is not greater than '%min%'" => "输入应大于'%min%'",
-    "The input is not greater or equal than '%min%'" => "输入应大于等于'%min%'",
+    "The input is not greater than or equal to '%min%'" => "输入应大于等于'%min%'",
 
     // Zend_Validator_Hex
     "Invalid type given. String expected" => "输入无效，请输入一个字符串",

--- a/languages/zh_TW/Zend_Validate.php
+++ b/languages/zh_TW/Zend_Validate.php
@@ -183,7 +183,7 @@ return [
 
     // Zend_Validator_GreaterThan
     "The input is not greater than '%min%'" => "輸入應大於'%min%'",
-    "The input is not greater or equal than '%min%'" => "輸入應大於等於'%min%'",
+    "The input is not greater than or equal to '%min%'" => "輸入應大於等於'%min%'",
 
     // Zend_Validator_Hex
     "Invalid type given. String expected" => "輸入無效，請輸入一個字符串",


### PR DESCRIPTION
- Missing the word `equal` and `to`

Origin: pt-br #16