### PR TITLE
Fixes Wrong german translation, "pass" should be "passt"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#40](https://github.com/zendframework/zend-i18n-resources/pull/40) fixes typo in
+  german translation for Zend\Validator\DateStep messages
 
 ## 2.6.0 - 2018-04-30
 

--- a/languages/de/Zend_Validate.php
+++ b/languages/de/Zend_Validate.php
@@ -77,7 +77,7 @@ return [
     // Zend\Validator\DateStep
     "Invalid type given. String, integer, array or DateTime expected" => "Ungültige Eingabe. Zeichenkette, Ganzzahl, Array oder Datums- und Zeitangabe erwartet",
     "The input does not appear to be a valid date" => "Die Eingabe scheint kein gültiges Datum zu sein",
-    "The input does not fit the date format '%format%'" => "Die Eingabe pass nicht zum Datumsformat '%format%'",
+    "The input does not fit the date format '%format%'" => "Die Eingabe passt nicht zum Datumsformat '%format%'",
     "The input is not a valid step" => "Die Eingabe ist kein gültiger Abschnitt",
 
     // Zend\Validator\Db\AbstractDb


### PR DESCRIPTION
- the translation has been linguistically improved 