### PR TITLE
CS fix: short array syntax

### DIFF
--- a/languages/sr_RS/Zend_Captcha.php
+++ b/languages/sr_RS/Zend_Captcha.php
@@ -10,7 +10,7 @@
 /**
  * sr_RS-Revision: 28.October.2015
  */
-return array(
+return [
     // Zend\Captcha\ReCaptcha
     "Missing captcha fields" => "Недостају captcha поља",
     "Failed to validate captcha" => "Неуспела captcha валидација",
@@ -20,4 +20,4 @@ return array(
     "Empty captcha value" => "Празна captcha вредност",
     "Captcha ID field is missing" => "Captcha ID поље недостаје",
     "Captcha value is wrong" => "Captcha вредност је погрешна",
-);
+];

--- a/languages/sr_RS/Zend_Validate.php
+++ b/languages/sr_RS/Zend_Validate.php
@@ -10,7 +10,7 @@
 /**
  * sr_RS-Revision: 28.October.2015
  */
-return array(
+return [
     // Zend\Authentication\Validator\Authentication
     "Invalid identity" => "Погрешан идентитет",
     "Identity is ambiguous" => "Идентитет је двосмислен",
@@ -305,4 +305,4 @@ return array(
     // Zend\Validator\Uri
     "Invalid type given. String expected" => "Унет је погрешан тип. Очекиван је String",
     "The input does not appear to be a valid Uri" => "Унет је неисправан Uri",
-);
+];


### PR DESCRIPTION
Somehow it was merged with `array()` syntax ... 